### PR TITLE
Hide animation should only be performed if alert is shown

### DIFF
--- a/src/components/styles/ButtonStyles.js
+++ b/src/components/styles/ButtonStyles.js
@@ -1,9 +1,6 @@
-import React from 'react';
-import { StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import config from '../../config';
-
-const {height, width} = Dimensions.get('window');
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/styles/MessageStyles.js
+++ b/src/components/styles/MessageStyles.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import config from '../../config';
 

--- a/src/components/styles/OverlayStyles.js
+++ b/src/components/styles/OverlayStyles.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { StyleSheet, Dimensions } from 'react-native';
 
 const {height, width} = Dimensions.get('window');

--- a/src/components/styles/TitleStyles.js
+++ b/src/components/styles/TitleStyles.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import config from '../../config';
 

--- a/src/containers/Alert.js
+++ b/src/containers/Alert.js
@@ -76,8 +76,6 @@ export default class Alert extends Component {
   };
 
   _handleHwBackEvent = () => {
-    const {closeOnHardwareBackPress} = this.props;
-
     if(this.state.showSelf) {
       this._springHide();
       return true;
@@ -139,7 +137,6 @@ export default class Alert extends Component {
 
   componentWillReceiveProps(nextProps) {
     const {show} = nextProps;
-    const {showOld} = this.props;
 
     if(show)
       this._springShow();

--- a/src/containers/Alert.js
+++ b/src/containers/Alert.js
@@ -53,17 +53,19 @@ export default class Alert extends Component {
   };
 
   _springHide = () => {
-    Animated.spring(
-      this.springValue,
-      {
-        toValue: 0,
-        tension: 10
-      }
-    ).start();
+    if (this.state.showSelf === true) {
+      Animated.spring(
+        this.springValue,
+        {
+          toValue: 0,
+          tension: 10
+        }
+      ).start();
 
-    setTimeout(() => {
-      this._toggleAlert();
-    }, 70);
+      setTimeout(() => {
+        this._toggleAlert();
+      }, 70);
+    }
   };
 
   _toggleAlert = (fromConstructor) => {

--- a/src/containers/styles/AlertStyles.js
+++ b/src/containers/styles/AlertStyles.js
@@ -1,9 +1,6 @@
-import React from 'react';
-import { StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import config from '../../config';
-
-const {height, width} = Dimensions.get('window');
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
On using react-router with this library, the overlay is shown when navigating between pages (with react-native-web).

This fix solves that issue by only hiding the alert when it was previously shown.