### PR TITLE
Better hardware back event support

### DIFF
--- a/src/containers/alert/index.js
+++ b/src/containers/alert/index.js
@@ -31,11 +31,16 @@ export default class Alert extends Component {
     if (show) this._springShow(true);
   }
 
-  componentDidMount() {
-    HwBackHandler.addEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
+  _addHwBackEvent() {
+    if(this.props.closeOnHardwareBackPress) HwBackHandler.addEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
+  }
+
+  _remHwBackEvent() {
+    if(this.props.closeOnHardwareBackPress) HwBackHandler.removeEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
   }
 
   _springShow = fromConstructor => {
+    this._addHwBackEvent();
     this._toggleAlert(fromConstructor);
     Animated.spring(this.springValue, {
       toValue: 1,
@@ -45,6 +50,7 @@ export default class Alert extends Component {
 
   _springHide = () => {
     if (this.state.showSelf === true) {
+      this._remHwBackEvent();
       Animated.spring(this.springValue, {
         toValue: 0,
         tension: 10
@@ -197,7 +203,7 @@ export default class Alert extends Component {
   }
 
   componentWillUnmount() {
-    HwBackHandler.removeEventListener(HW_BACK_EVENT);
+    if(this.state.showSelf) this._remHwBackEvent();
   }
 }
 

--- a/src/containers/alert/index.js
+++ b/src/containers/alert/index.js
@@ -32,11 +32,11 @@ export default class Alert extends Component {
   }
 
   _addHwBackEvent() {
-    if(this.props.closeOnHardwareBackPress) HwBackHandler.addEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
+    HwBackHandler.addEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
   }
 
   _remHwBackEvent() {
-    if(this.props.closeOnHardwareBackPress) HwBackHandler.removeEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
+    HwBackHandler.removeEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
   }
 
   _springShow = fromConstructor => {


### PR DESCRIPTION
This pull request has fixed the the issues presented in issue #17.

Reasons:
- The listener inside awesome alert can block up previous listeners if it's not removed or if it doesn't return true
- The reason why we don't want it to return false is so that the app doesn't close when the only thing visible is the alert
- This also doesn't require people to pass in a custom back handler function to AAlert

 Changes Made:
- Changed the HwBack listener so that it now only removes the specific HW back event in awesome alert
- Moved the listeners into the hide and show functions