### PR TITLE
Pass hardware handler reference into removeListener

### DIFF
--- a/src/containers/alert/index.js
+++ b/src/containers/alert/index.js
@@ -197,7 +197,7 @@ export default class Alert extends Component {
   }
 
   componentWillUnmount() {
-    HwBackHandler.removeEventListener(HW_BACK_EVENT);
+    HwBackHandler.removeEventListener(HW_BACK_EVENT, this._handleHwBackEvent);
   }
 }
 


### PR DESCRIPTION
Simple fix to pass in the hardware back handler so that it's properly removed when the alert is unmounted, which is common problem in custom view handlers.