### PR TITLE
fix: renaming method componentWillReceiveProps

### DIFF
--- a/src/containers/alert/index.js
+++ b/src/containers/alert/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 import {
   Text,
   Animated,
@@ -8,15 +8,15 @@ import {
   ActivityIndicator,
   BackAndroid,
   BackHandler
-} from 'react-native';
+} from "react-native";
 
-import PropTypes from 'prop-types';
-import config from '../../config';
+import PropTypes from "prop-types";
+import config from "../../config";
 
-import styles from './style';
+import styles from "./style";
 
 const HwBackHandler = BackHandler || BackAndroid;
-const HW_BACK_EVENT = 'hardwareBackPress';
+const HW_BACK_EVENT = "hardwareBackPress";
 
 export default class Alert extends Component {
   constructor(props) {
@@ -188,7 +188,7 @@ export default class Alert extends Component {
     return null;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { show } = nextProps;
     const { showSelf } = this.state;
 

--- a/src/containers/alert/index.js
+++ b/src/containers/alert/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component } from 'react';
 import {
   Text,
   Animated,
@@ -8,15 +8,15 @@ import {
   ActivityIndicator,
   BackAndroid,
   BackHandler
-} from "react-native";
+} from 'react-native';
 
-import PropTypes from "prop-types";
-import config from "../../config";
+import PropTypes from 'prop-types';
+import config from '../../config';
 
-import styles from "./style";
+import styles from './style';
 
 const HwBackHandler = BackHandler || BackAndroid;
-const HW_BACK_EVENT = "hardwareBackPress";
+const HW_BACK_EVENT = 'hardwareBackPress';
 
 export default class Alert extends Component {
   constructor(props) {


### PR DESCRIPTION
I am using RN version 0.61 and I am getting the following warnings:

> Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.
> 
> Move data fetching code or side effects to componentDidUpdate.
> If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
> Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run npx react-codemod rename-unsafe-lifecycles in your project source folder.
> Please update the following components: AwesomeAlert

Workaround: Update method name as proposed by React documentation, componentWillReceiveProps to UNSAFE_componentWillReceiveProps