### PR TITLE
update customView propType to allow any valid react node

### DIFF
--- a/src/AwesomeAlert.js
+++ b/src/AwesomeAlert.js
@@ -234,7 +234,7 @@ AwesomeAlert.propTypes = {
   confirmButtonColor: PropTypes.string,
   onCancelPressed: PropTypes.func,
   onConfirmPressed: PropTypes.func,
-  customView: PropTypes.object,
+  customView: PropTypes.node,
 };
 
 AwesomeAlert.defaultProps = {


### PR DESCRIPTION
Avoids prop error when an array of React nodes is passed to customView