### PR TITLE
Add ScrollView to modal content

### DIFF
--- a/src/AwesomeAlert.js
+++ b/src/AwesomeAlert.js
@@ -3,6 +3,7 @@ import {
   Text,
   Animated,
   View,
+  ScrollView,
   TouchableOpacity,
   TouchableWithoutFeedback,
   ActivityIndicator,
@@ -170,18 +171,20 @@ export default class AwesomeAlert extends Component {
         <Animated.View
           style={[styles.contentContainer, animation, contentContainerStyle]}
         >
-          <View style={[styles.content, contentStyle]}>
-            {showProgress ? (
-              <ActivityIndicator size={progressSize} color={progressColor} />
-            ) : null}
-            {title ? (
-              <Text style={[styles.title, titleStyle]}>{title}</Text>
-            ) : null}
-            {message ? (
-              <Text style={[styles.message, messageStyle]}>{message}</Text>
-            ) : null}
-            {customView}
-          </View>
+          <ScrollView>
+            <View style={[styles.content, contentStyle]}>
+              {showProgress ? (
+                <ActivityIndicator size={progressSize} color={progressColor} />
+              ) : null}
+              {title ? (
+                <Text style={[styles.title, titleStyle]}>{title}</Text>
+              ) : null}
+              {message ? (
+                <Text style={[styles.message, messageStyle]}>{message}</Text>
+              ) : null}
+              {customView}
+            </View>
+          </ScrollView>
           <View style={[styles.action, actionContainerStyle]}>
             {showCancelButton ? this._renderButton(cancelButtonData) : null}
             {showConfirmButton ? this._renderButton(confirmButtonData) : null}


### PR DESCRIPTION
#### Motivation
When we have a large message we can not see all message.

#### Solution
Add the content of modal as a child of ScrollView it will enable to scroll the message modal.

#### Changelog

[x] Fix large messages to show correctly on modal

#### Before
![before](https://user-images.githubusercontent.com/8150298/95068690-fb616280-06db-11eb-864c-9408f8d80ede.jpg)


#### After
![after](https://user-images.githubusercontent.com/8150298/95068701-00261680-06dc-11eb-85c2-0a12e9a7485e.jpg)
