### PR TITLE
Fix animation bug where alert cannot be hidden

### DIFF
--- a/src/AwesomeAlert.js
+++ b/src/AwesomeAlert.js
@@ -56,7 +56,7 @@ export default class AwesomeAlert extends Component {
         toValue: 0,
         tension: 10,
         useNativeDriver,
-      }).start(({finished) => {
+      }).start(({finished}) => {
         if (finished) {
           this._toggleAlert();
           this._onDismiss();

--- a/src/AwesomeAlert.js
+++ b/src/AwesomeAlert.js
@@ -56,9 +56,11 @@ export default class AwesomeAlert extends Component {
         toValue: 0,
         tension: 10,
         useNativeDriver,
-      }).start(() => {
-        this._toggleAlert();
-        this._onDismiss();
+      }).start(({finished) => {
+        if (finished) {
+          this._toggleAlert();
+          this._onDismiss();
+        }
       });
     }
   };

--- a/src/AwesomeAlert.js
+++ b/src/AwesomeAlert.js
@@ -56,12 +56,10 @@ export default class AwesomeAlert extends Component {
         toValue: 0,
         tension: 10,
         useNativeDriver,
-      }).start();
-
-      setTimeout(() => {
+      }).start(() => {
         this._toggleAlert();
         this._onDismiss();
-      }, 70);
+      });
     }
   };
 


### PR DESCRIPTION
It seems in memory intensive situations that `onDismiss` is called before the animation has completed.

In such situations, where the you do not allow the user to dismiss, and you rely on the `onDismiss` callback to navigation to a new screen (say with react-navigation) you can have an Alert that remains on the screen and requires the user to close out of the app entirely.

The solution was to use the `CompositeAnimation.start()` callback, and wait until the animation is `finished` before calling the `onDismiss` callback.