### PR TITLE
Fix outside click no longer working after closed once

### DIFF
--- a/src/AwesomeAlert.js
+++ b/src/AwesomeAlert.js
@@ -84,7 +84,9 @@ export default class AwesomeAlert extends Component {
 
   _onTapOutside = () => {
     const { closeOnTouchOutside } = this.props;
-    if (closeOnTouchOutside) this._springHide();
+    if (closeOnTouchOutside) {
+      this.props.onCancelPressed && this.props.onCancelPressed();
+    }
   };
 
   _onDismiss = () => {


### PR DESCRIPTION
Fixes the issue where you would tap outside the prompt and it would no longer open. This happens because the modal is closed but the state is not updated. My solution was to simply call the `onCancelPressed` which is also called when the "cancel" option is clicked.